### PR TITLE
Add polymer ready extension for chrome

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@
 * [Snippets for Atom editor](https://atom.io/packages/polymer-snippets)
 * [Snippets for Sublime Text editor](https://packagecontrol.io/packages/Polymer%20%26%20Web%20Component%20Snippets)
 * [polyup](https://github.com/PolymerLabs/polyup) A helpful assistant for migrating from Polymer v0.5 to 1.0. Does many of the boring mechanical parts for you. [docs](http://polymerlabs.github.io/polyup/)
+* [Polymer Ready](https://chrome.google.com/webstore/detail/polymer-ready/aaifiopbmiecbpladpjaoemohhfjcbdk) Show an icon in the address bar when it detects some Polymer and Custom components.
 
 ## Testing
 * [Web components tester](https://github.com/Polymer/web-component-tester) Makes testing your web components a breeze!


### PR DESCRIPTION
A Chrome extension to check if there are web components in our page and to link to the documentation.
